### PR TITLE
Info.plist provisioner

### DIFF
--- a/Sources/xpmkit/Utils/InfoPlistProvisioner.swift
+++ b/Sources/xpmkit/Utils/InfoPlistProvisioner.swift
@@ -17,7 +17,7 @@ class InfoPlistProvisioner: InfoPlistProvisioning {
     /// Initializes the provisioner with its attributes.
     ///
     /// - Parameter fileHandler: file handler.
-    init(fileHandler: FileHandling) {
+    init(fileHandler: FileHandling = FileHandler()) {
         self.fileHandler = fileHandler
     }
 

--- a/Sources/xpmkit/Utils/InfoPlistProvisioner.swift
+++ b/Sources/xpmkit/Utils/InfoPlistProvisioner.swift
@@ -1,0 +1,90 @@
+import Basic
+import Foundation
+import xpmcore
+
+protocol InfoPlistProvisioning: AnyObject {
+    func generate(path: AbsolutePath, platform: Platform, product: Product) throws
+}
+
+/// Creates a base Info.plist. This is intended to be used from the init command.
+class InfoPlistProvisioner: InfoPlistProvisioning {
+
+    // MARK: - Attributes
+
+    /// File handler.
+    private let fileHandler: FileHandling
+
+    /// Initializes the provisioner with its attributes.
+    ///
+    /// - Parameter fileHandler: file handler.
+    init(fileHandler: FileHandling) {
+        self.fileHandler = fileHandler
+    }
+
+    /// Generates the Info.plist at the given path.
+    ///
+    /// - Parameters:
+    ///   - path: the absolute path to the file (/path/to/Info.plist)
+    ///   - platform: platform of the target the Info.plist file will be generated for.
+    ///   - product: type of product of the target the Info.plist will be generated for.
+    /// - Throws: an error if the Info.plist file cannot be generated.
+    func generate(path: AbsolutePath, platform: Platform, product: Product) throws {
+        let dictinary = base(platform: platform, product: product)
+        let data = try PropertyListSerialization.data(fromPropertyList: dictinary, format: .xml, options: 0)
+        try data.write(to: path.url)
+    }
+
+    /// Gets the base Info.plist content for the given platform and product.
+    ///
+    /// - Parameters:
+    ///   - platform: platform of the target the Info.plist file will be generated for.
+    ///   - product: type of product of the target the Info.plist will be generated for.
+    /// - Returns: base Info.plist content.
+    fileprivate func base(platform: Platform, product: Product) -> [String: Any] {
+        var base: [String: Any] = [:]
+        base["CFBundleDevelopmentRegion"] = "$(DEVELOPMENT_LANGUAGE)"
+        base["CFBundleExecutable"] = "$(EXECUTABLE_NAME)"
+        base["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
+        base["CFBundleInfoDictionaryVersion"] = "6.0"
+        base["CFBundleName"] = "$(PRODUCT_NAME)"
+        base["CFBundleShortVersionString"] = "1.0"
+        base["NSHumanReadableCopyright"] = "Copyright ©. All rights reserved."
+
+        // Application
+        if product == .app {
+            base["CFBundleVersion"] = "1"
+            base["CFBundlePackageType"] = "APPL"
+
+            // Framework
+        } else {
+            base["CFBundleVersion"] = "$(CURRENT_PROJECT_VERSION)"
+            base["CFBundlePackageType"] = "FMWK"
+            base["NSPrincipalClass"] = ""
+        }
+
+        // macOS application
+        if product == .app && platform == .macOS {
+            base["LSMinimumSystemVersion"] = "$(MACOSX_DEPLOYMENT_TARGET)"
+            base["NSPrincipalClass"] = "NSApplication"
+            base["CFBundleIconFile"] = ""
+        }
+
+        // iOS application
+        if product == .app && platform == .iOS {
+            base["LSRequiresIPhoneOS"] = true
+            base["UIRequiredDeviceCapabilities"] = ["armv7"]
+            base["UISupportedInterfaceOrientations"] = [
+                "UIInterfaceOrientationPortrait",
+                "UIInterfaceOrientationLandscapeLeft",
+                "UIInterfaceOrientationLandscapeRight",
+            ]
+            base["UISupportedInterfaceOrientations~ipad"] = [
+                "UIInterfaceOrientationPortrait",
+                "UIInterfaceOrientationPortraitUpsideDown",
+                "UIInterfaceOrientationLandscapeLeft",
+                "UIInterfaceOrientationLandscapeRight",
+            ]
+        }
+        return base
+    }
+}

--- a/Tests/xpmkitTests/Utils/InfoPlistProvisionerTests.swift
+++ b/Tests/xpmkitTests/Utils/InfoPlistProvisionerTests.swift
@@ -1,0 +1,110 @@
+import Basic
+import Foundation
+import XCTest
+@testable import xpmkit
+
+final class InfoPlistProvisionerTests: XCTestCase {
+    var subject: InfoPlistProvisioner!
+    var tmpDir: TemporaryDirectory!
+    var path: AbsolutePath!
+
+    override func setUp() {
+        super.setUp()
+        subject = InfoPlistProvisioner()
+        tmpDir = try! TemporaryDirectory(removeTreeOnDeinit: true)
+        path = tmpDir.path.appending(component: "Info.plist")
+    }
+
+    func test_generate_when_ios_app() throws {
+        let got = try provision(platform: .iOS, product: .app)
+        let expected: [String: Any] = [
+            "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+            "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+            "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleName": "$(PRODUCT_NAME)",
+            "CFBundleShortVersionString": "1.0",
+            "NSHumanReadableCopyright": "Copyright ©. All rights reserved.",
+            "CFBundleVersion": "1",
+            "CFBundlePackageType": "APPL",
+            "LSRequiresIPhoneOS": true,
+            "UIRequiredDeviceCapabilities": ["armv7"],
+            "UISupportedInterfaceOrientations": [
+                "UIInterfaceOrientationPortrait",
+                "UIInterfaceOrientationLandscapeLeft",
+                "UIInterfaceOrientationLandscapeRight",
+            ],
+            "UISupportedInterfaceOrientations~ipad": [
+                "UIInterfaceOrientationPortrait",
+                "UIInterfaceOrientationPortraitUpsideDown",
+                "UIInterfaceOrientationLandscapeLeft",
+                "UIInterfaceOrientationLandscapeRight",
+            ],
+        ]
+        XCTAssertEqual(NSDictionary(dictionary: got),
+                       NSDictionary(dictionary: expected))
+    }
+
+    func test_generate_when_macos_app() throws {
+        let got = try provision(platform: .macOS, product: .app)
+        let expected: [String: Any] = [
+            "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+            "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+            "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleName": "$(PRODUCT_NAME)",
+            "CFBundleShortVersionString": "1.0",
+            "NSHumanReadableCopyright": "Copyright ©. All rights reserved.",
+            "CFBundleVersion": "1",
+            "CFBundlePackageType": "APPL",
+            "LSMinimumSystemVersion": "$(MACOSX_DEPLOYMENT_TARGET)",
+            "NSPrincipalClass": "NSApplication",
+            "CFBundleIconFile": "",
+        ]
+        XCTAssertEqual(NSDictionary(dictionary: got),
+                       NSDictionary(dictionary: expected))
+    }
+
+    func test_generate_when_macos_framework() throws {
+        let got = try provision(platform: .iOS, product: .framework)
+        let expected: [String: Any] = [
+            "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+            "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+            "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleName": "$(PRODUCT_NAME)",
+            "CFBundleShortVersionString": "1.0",
+            "NSHumanReadableCopyright": "Copyright ©. All rights reserved.",
+            "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
+            "CFBundlePackageType": "FMWK",
+            "NSPrincipalClass": "",
+        ]
+        XCTAssertEqual(NSDictionary(dictionary: got),
+                       NSDictionary(dictionary: expected))
+    }
+
+    func test_generate_when_ios_framework() throws {
+        let got = try provision(platform: .macOS, product: .framework)
+        let expected: [String: Any] = [
+            "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+            "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+            "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleName": "$(PRODUCT_NAME)",
+            "CFBundleShortVersionString": "1.0",
+            "NSHumanReadableCopyright": "Copyright ©. All rights reserved.",
+            "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)",
+            "CFBundlePackageType": "FMWK",
+            "NSPrincipalClass": "",
+        ]
+        XCTAssertEqual(NSDictionary(dictionary: got),
+                       NSDictionary(dictionary: expected))
+    }
+
+    func provision(platform: Platform, product: Product) throws -> [String: AnyHashable] {
+        try subject.generate(path: path, platform: platform, product: product)
+        let data = try Data(contentsOf: path.url)
+        let object = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+        return (object as? [String: AnyHashable]) ?? [:]
+    }
+}


### PR DESCRIPTION
### Short description 📝
Add `InfoPlistProvisioner` to be used from the init command to generate the default `Info.plist` files.