### PR TITLE
Improve InitCommand

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "Glob",
+        "repositoryURL": "git@github.com:Bouke/Glob.git",
+        "state": {
+          "branch": null,
+          "revision": "f5308125a46fcd4ea265d0e191a851aa67796c03",
+          "version": null
+        }
+      },
+      {
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager",
         "state": {
@@ -24,7 +33,7 @@
         "repositoryURL": "git@github.com:xcode-project-manager/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "7ff584c3a0114eac59e5cc711f96c921a6c3b26e",
+          "revision": "9e07138d737e88b940fbba8c503667339fe95330",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
                  targets: ["ProjectDescription"]),
     ],
     dependencies: [
-        .package(url: "git@github.com:xcode-project-manager/xcodeproj.git", .revision("7ff584c3a0114eac59e5cc711f96c921a6c3b26e")),
+        .package(url: "git@github.com:xcode-project-manager/xcodeproj.git", .revision("9e07138d737e88b940fbba8c503667339fe95330")),
         .package(url: "https://github.com/apple/swift-package-manager", .revision("3e71e57db41ebb32ccec1841a7e26c428a9c08c5")),
     ],
     targets: [

--- a/Sources/xpmcore/Extensions/AbsolutePath+Extras.swift
+++ b/Sources/xpmcore/Extensions/AbsolutePath+Extras.swift
@@ -16,25 +16,6 @@ extension AbsolutePath {
     }
 
     public func glob(_ pattern: String) -> [AbsolutePath] {
-        var gt = glob_t()
-        let cPattern = strdup(appending(RelativePath(pattern)).asString)
-        defer {
-            globfree(&gt)
-            free(cPattern)
-        }
-
-        let flags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
-        if systemGlob(cPattern, flags, nil, &gt) == 0 {
-            let matchc = gt.gl_matchc
-            return (0 ..< Int(matchc)).compactMap { index in
-                if let path = String(validatingUTF8: gt.gl_pathv[index]!) {
-                    return AbsolutePath(path)
-                }
-                return nil
-            }
-        }
-
-        // GLOB_NOMATCH
-        return []
+        return Glob(pattern: appending(RelativePath(pattern)).asString).paths.map({ AbsolutePath($0) })
     }
 }

--- a/Sources/xpmcore/Utils/Glob.swift
+++ b/Sources/xpmcore/Utils/Glob.swift
@@ -1,0 +1,214 @@
+//
+//  Created by Eric Firestone on 3/22/16.
+//  Copyright © 2016 Square, Inc. All rights reserved.
+//  Released under the Apache v2 License.
+//
+//  Adapted from https://gist.github.com/efirestone/ce01ae109e08772647eb061b3bb387c3
+import Foundation
+
+public let GlobBehaviorBashV3 = Glob.Behavior(
+    supportsGlobstar: false,
+    includesFilesFromRootOfGlobstar: false,
+    includesDirectoriesInResults: true,
+    includesFilesInResultsIfTrailingSlash: false
+)
+public let GlobBehaviorBashV4 = Glob.Behavior(
+    supportsGlobstar: true, // Matches Bash v4 with "shopt -s globstar" option
+    includesFilesFromRootOfGlobstar: true,
+    includesDirectoriesInResults: true,
+    includesFilesInResultsIfTrailingSlash: false
+)
+public let GlobBehaviorGradle = Glob.Behavior(
+    supportsGlobstar: true,
+    includesFilesFromRootOfGlobstar: true,
+    includesDirectoriesInResults: false,
+    includesFilesInResultsIfTrailingSlash: true
+)
+
+/**
+ Finds files on the file system using pattern matching.
+ */
+public class Glob: Collection {
+    /**
+     * Different glob implementations have different behaviors, so the behavior of this
+     * implementation is customizable.
+     */
+    public struct Behavior {
+        // If true then a globstar ("**") causes matching to be done recursively in subdirectories.
+        // If false then "**" is treated the same as "*"
+        let supportsGlobstar: Bool
+
+        // If true the results from the directory where the globstar is declared will be included as well.
+        // For example, with the pattern "dir/**/*.ext" the fie "dir/file.ext" would be included if this
+        // property is true, and would be omitted if it's false.
+        let includesFilesFromRootOfGlobstar: Bool
+
+        // If false then the results will not include directory entries. This does not affect recursion depth.
+        let includesDirectoriesInResults: Bool
+
+        // If false and the last characters of the pattern are "**/" then only directories are returned in the results.
+        let includesFilesInResultsIfTrailingSlash: Bool
+
+        public init(supportsGlobstar: Bool, includesFilesFromRootOfGlobstar: Bool, includesDirectoriesInResults: Bool, includesFilesInResultsIfTrailingSlash: Bool) {
+            self.supportsGlobstar = supportsGlobstar
+            self.includesFilesFromRootOfGlobstar = includesFilesFromRootOfGlobstar
+            self.includesDirectoriesInResults = includesDirectoriesInResults
+            self.includesFilesInResultsIfTrailingSlash = includesFilesInResultsIfTrailingSlash
+        }
+    }
+
+    public static var defaultBehavior = GlobBehaviorBashV4
+
+    private var isDirectoryCache = [String: Bool]()
+
+    public let behavior: Behavior
+    var paths = [String]()
+    public var startIndex: Int { return paths.startIndex }
+    public var endIndex: Int { return paths.endIndex }
+
+    public init(pattern: String, behavior: Behavior = Glob.defaultBehavior) {
+        self.behavior = behavior
+
+        var adjustedPattern = pattern
+        let hasTrailingGlobstarSlash = pattern.hasSuffix("**/")
+        var includeFiles = !hasTrailingGlobstarSlash
+
+        if behavior.includesFilesInResultsIfTrailingSlash {
+            includeFiles = true
+            if hasTrailingGlobstarSlash {
+                // Grab the files too.
+                adjustedPattern += "*"
+            }
+        }
+
+        let patterns = behavior.supportsGlobstar ? expandGlobstar(pattern: adjustedPattern) : [adjustedPattern]
+
+        for pattern in patterns {
+            var gt = glob_t()
+            if executeGlob(pattern: pattern, gt: &gt) {
+                populateFiles(gt: gt, includeFiles: includeFiles)
+            }
+
+            globfree(&gt)
+        }
+
+        paths = Array(Set(paths)).sorted { lhs, rhs in
+            lhs.compare(rhs) != ComparisonResult.orderedDescending
+        }
+
+        clearCaches()
+    }
+
+    // MARK: Private
+
+    private var globalFlags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
+
+    private func executeGlob(pattern: UnsafePointer<CChar>, gt: UnsafeMutablePointer<glob_t>) -> Bool {
+        return 0 == glob(pattern, globalFlags, nil, gt)
+    }
+
+    private func expandGlobstar(pattern: String) -> [String] {
+        guard pattern.contains("**") else {
+            return [pattern]
+        }
+
+        var results = [String]()
+        var parts = pattern.components(separatedBy: "**")
+        let firstPart = parts.removeFirst()
+        var lastPart = parts.joined(separator: "**")
+
+        let fileManager = FileManager.default
+
+        var directories: [String]
+
+        do {
+            directories = try fileManager.subpathsOfDirectory(atPath: firstPart).flatMap { subpath in
+                let fullPath = NSString(string: firstPart).appendingPathComponent(subpath)
+                guard isDirectory(path: fullPath) else { return nil }
+                return fullPath
+            }
+        } catch {
+            directories = []
+            print("Error parsing file system item: \(error)")
+        }
+
+        if behavior.includesFilesFromRootOfGlobstar {
+            // Check the base directory for the glob star as well.
+            directories.insert(firstPart, at: 0)
+
+            // Include the globstar root directory ("dir/") in a pattern like "dir/**" or "dir/**/"
+            if lastPart.isEmpty {
+                results.append(firstPart)
+            }
+        }
+
+        if lastPart.isEmpty {
+            lastPart = "*"
+        }
+        for directory in directories {
+            let partiallyResolvedPattern = NSString(string: directory).appendingPathComponent(lastPart)
+            results.append(contentsOf: expandGlobstar(pattern: partiallyResolvedPattern))
+        }
+
+        return results
+    }
+
+    private func isDirectory(path: String) -> Bool {
+        if let isDirectory = isDirectoryCache[path] {
+            return isDirectory
+        }
+
+        #if os(macOS)
+            var isDirectoryBool = ObjCBool(false)
+        #else
+            var isDirectoryBool = false
+        #endif
+        var isDirectory = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectoryBool)
+        #if os(macOS)
+            isDirectory = isDirectory && isDirectoryBool.boolValue
+        #else
+            isDirectory = isDirectory && isDirectoryBool
+        #endif
+
+        isDirectoryCache[path] = isDirectory
+
+        return isDirectory
+    }
+
+    private func clearCaches() {
+        isDirectoryCache.removeAll()
+    }
+
+    private func populateFiles(gt: glob_t, includeFiles: Bool) {
+        let includeDirectories = behavior.includesDirectoriesInResults
+        #if os(Linux)
+            let matchesCount = Int(gt.gl_pathc)
+        #else
+            let matchesCount = Int(gt.gl_matchc)
+        #endif
+        for i in 0 ..< matchesCount {
+            if let path = String(validatingUTF8: gt.gl_pathv[i]!) {
+                if !includeFiles || !includeDirectories {
+                    let isDirectory = self.isDirectory(path: path)
+                    if (!includeFiles && !isDirectory) || (!includeDirectories && isDirectory) {
+                        continue
+                    }
+                }
+
+                paths.append(path)
+            }
+        }
+    }
+
+    // MARK: Subscript Support
+
+    public subscript(i: Int) -> String {
+        return paths[i]
+    }
+
+    // MARK: IndexableBase
+
+    public func index(after i: Glob.Index) -> Glob.Index {
+        return i + 1
+    }
+}

--- a/Sources/xpmkit/Commands/InitCommand.swift
+++ b/Sources/xpmkit/Commands/InitCommand.swift
@@ -35,22 +35,54 @@ public class InitCommand: NSObject, Command {
     public static let command = "init"
 
     /// Command description.
-    public static let overview = "Initializes a Project.swift in the current folder."
+    public static let overview = "Initializes a project in the current directory."
 
-    /// Path argument.
-    let pathArgument: OptionArgument<String>
+    /// Platform argument.
+    let platformArgument: OptionArgument<String>
 
-    /// Context
-    let context: CommandsContexting
+    /// Product argument.
+    let productArgument: OptionArgument<String>
 
-    public required init(parser: ArgumentParser) {
+    /// File handler.
+    let fileHandler: FileHandling
+
+    /// Printer.
+    let printer: Printing
+
+    /// Info.plist provisioner
+    let infoplistProvisioner: InfoPlistProvisioning
+
+    public required convenience init(parser: ArgumentParser) {
+        self.init(parser: parser,
+                  fileHandler: FileHandler(),
+                  printer: Printer(),
+                  infoplistProvisioner: InfoPlistProvisioner())
+    }
+
+    init(parser: ArgumentParser,
+         fileHandler: FileHandling,
+         printer: Printing,
+         infoplistProvisioner: InfoPlistProvisioning) {
         let subParser = parser.add(subparser: InitCommand.command, overview: InitCommand.overview)
-        pathArgument = subParser.add(option: "--path",
-                                     shortName: "-p",
-                                     kind: String.self,
-                                     usage: "The path where the Project.swift file will be generated",
-                                     completion: .filename)
-        context = CommandsContext()
+        productArgument = subParser.add(option: "--product",
+                                        shortName: nil,
+                                        kind: String.self,
+                                        usage: "The product (app or framework) the generated project will build.",
+                                        completion: ShellCompletion.values([
+                                            (value: "app", description: "Application"),
+                                            (value: "framework", description: "Framework"),
+        ]))
+        platformArgument = subParser.add(option: "--platform",
+                                         shortName: nil,
+                                         kind: String.self,
+                                         usage: "The platform (ios or macos) the product will be for.",
+                                         completion: ShellCompletion.values([
+                                             (value: "ios", description: "iOS platform"),
+                                             (value: "macos", description: "macOS platform"),
+        ]))
+        self.fileHandler = fileHandler
+        self.printer = printer
+        self.infoplistProvisioner = infoplistProvisioner
     }
 
     /// Runs the command.
@@ -58,43 +90,32 @@ public class InitCommand: NSObject, Command {
     /// - Parameter arguments: input arguments.
     /// - Throws: throws an error if the execution fails.
     public func run(with arguments: ArgumentParser.Result) throws {
-        var path: AbsolutePath! = arguments
-            .get(pathArgument)
-            .map({ AbsolutePath($0) })
-            .map({ $0.appending(component: Constants.Manifest.project) })
-        if path == nil {
-            path = AbsolutePath.current.appending(component: Constants.Manifest.project)
-        }
-        if context.fileHandler.exists(path) {
-            throw InitCommandError.alreadyExists(path)
-        }
-        guard let projectName = path.parentDirectory.components.last else {
-            throw InitCommandError.ungettableProjectName(path)
-        }
-        let projectSwift = self.projectSwift(name: projectName)
-        try projectSwift.write(toFile: path.asString,
-                               atomically: true,
-                               encoding: .utf8)
-        context.printer.print(section: "Project.swift generated at path \(path.asString)")
+        let product = try self.product(arguments: arguments)
+        let platform = try self.platform(arguments: arguments)
+        let name = try self.name()
+        try generateProjectSwift(name: name, platform: platform, product: product)
+        try generateSources(name: name, platform: platform, product: product)
+        try generateTests(name: name)
+        try generatePlists(platform: platform, product: product)
     }
 
-    fileprivate func projectSwift(name: String) -> String {
-        return """
+    fileprivate func generateProjectSwift(name: String, platform: Platform, product: Product) throws {
+        let content = """
         import ProjectDescription
         
-         let project = Project(name: "{{NAME}}",
+         let project = Project(name: "\(name)",
                       schemes: [
                           /* Project schemes are defined here */
-                          Scheme(name: "{{NAME}}",
+                          Scheme(name: "\(name)",
                                  shared: true,
-                                 buildAction: BuildAction(targets: ["{{NAME}}"])),
+                                 buildAction: BuildAction(targets: ["\(name)"])),
                       ],
                       settings: Settings(base: [:]),
                       targets: [
-                          Target(name: "{{NAME}}",
-                                 platform: .iOS,
-                                 product: .app,
-                                 bundleId: "com.xcodepm.{{NAME}}",
+                          Target(name: "\(name)",
+                                 platform: .\(platform.rawValue),
+                                 product: .\(product.rawValue),
+                                 bundleId: "com.xcodepm.\(name)",
                                  infoPlist: "Info.plist",
                                  dependencies: [
                                      /* Target dependencies can be defined here */
@@ -102,12 +123,173 @@ public class InitCommand: NSObject, Command {
                                  ],
                                  settings: nil,
                                  buildPhases: [
-                                    
-                                     .sources([.sources("./Sources/*")]),
+                                     .sources([.sources("./Sources/**/*.swift")]),
                                      /* Other build phases can be added here */
                                      /* .resources([.include(["./Resources/**/*"])]) */
                                 ]),
+                          Target(name: "\(name)Tests",
+                                 platform: .\(platform.rawValue),
+                                 product: .unitTests,
+                                 bundleId: "com.xcodepm.\(name)Tests",
+                                 infoPlist: "Tests.plist",
+                                 dependencies: [
+                                   .target(name: "\(name)")
+                                 ],
+                                 settings: nil,
+                                 buildPhases: [
+                                     .sources([.sources("./Tests/**/*.swift")]),
+                                ]),
+        
+                        
                     ])
-        """.replacingOccurrences(of: "{{NAME}}", with: name)
+        """
+        try content.write(to: fileHandler.currentPath.appending(component: "Project.swift").url, atomically: true, encoding: .utf8)
+    }
+
+    fileprivate func generatePlists(platform: Platform, product: Product) throws {
+        try infoplistProvisioner.generate(path: fileHandler.currentPath.appending(component: "Info.plist"),
+                                          platform: platform,
+                                          product: product)
+        try infoplistProvisioner.generate(path: fileHandler.currentPath.appending(component: "Tests.plist"),
+                                          platform: platform,
+                                          product: .unitTests)
+    }
+
+    fileprivate func generateSources(name: String, platform: Platform, product: Product) throws {
+        let path = fileHandler.currentPath.appending(component: "Sources")
+
+        if fileHandler.exists(path) {
+            throw InitCommandError.alreadyExists(path)
+        }
+        try fileHandler.createFolder(path)
+
+        var content: String!
+        var filename: String!
+
+        if platform == .macOS && product == .app {
+            filename = "AppDelegate.swift"
+            content = """
+            import Cocoa
+            
+            @NSApplicationMain
+            class AppDelegate: NSObject, NSApplicationDelegate {
+            
+                @IBOutlet weak var window: NSWindow!
+            
+                func applicationDidFinishLaunching(_ aNotification: Notification) {
+                    // Insert code here to initialize your application
+                }
+            
+                func applicationWillTerminate(_ aNotification: Notification) {
+                    // Insert code here to tear down your application
+                }
+            
+            }
+            """
+        } else if platform == .iOS && product == .app {
+            filename = "AppDelegate.swift"
+
+            content = """
+            import UIKit
+            
+            @UIApplicationMain
+            class AppDelegate: UIResponder, UIApplicationDelegate {
+            
+                var window: UIWindow?
+            
+                func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+                    window = UIWindow(frame: UIScreen.main.bounds)
+                    let viewController = UIViewController()
+                    viewController.view.backgroundColor = .white
+                    window?.rootViewController = viewController
+                    window?.makeKeyAndVisible()
+                    return true
+                }
+            
+            }
+            """
+        } else {
+            filename = "\(name).swift"
+            content = """
+            import Foundation
+            
+            class \(name) {
+            
+            }
+            """
+        }
+
+        try content.write(to: path.appending(component: filename).url, atomically: true, encoding: .utf8)
+    }
+
+    /// Generates the tests folder with a base tests file.
+    ///
+    /// - Parameter name: project name.
+    /// - Throws: an error if the tests folder cannot be created.
+    fileprivate func generateTests(name: String) throws {
+        let path = fileHandler.currentPath.appending(component: "Tests")
+
+        if fileHandler.exists(path) {
+            throw InitCommandError.alreadyExists(path)
+        }
+        try fileHandler.createFolder(path)
+
+        let content = """
+        import Foundation
+        import XCTest
+        
+        @testable import \(name)
+
+        final class \(name)Tests: XCTestCase {
+        
+        }
+        """
+        try content.write(to: path.appending(component: "\(name)Tests.swift").url, atomically: true, encoding: .utf8)
+    }
+
+    /// Returns the name that should be used for the project.
+    ///
+    /// - Returns: project name.
+    /// - Throws: an error if the name cannot be obtained.
+    fileprivate func name() throws -> String {
+        if let name = fileHandler.currentPath.components.last {
+            return name
+        } else {
+            throw InitCommandError.ungettableProjectName(AbsolutePath.current)
+        }
+    }
+
+    /// Returns the product by parsing the arguments.
+    ///
+    /// - Parameter arguments: argument parser result.
+    /// - Returns: the product that should be used for the project.
+    fileprivate func product(arguments: ArgumentParser.Result) throws -> Product {
+        if let productString = arguments.get(self.productArgument) {
+            let valid = ["app", "framework"]
+            if valid.contains(productString), let product = Product(rawValue: productString) {
+                return product
+            } else {
+                throw ArgumentParserError.invalidValue(argument: "product", error: .custom("Product should be either app or framework"))
+            }
+        } else {
+            return .app
+        }
+    }
+
+    /// Returns the platform by parsing the arguments.
+    ///
+    /// - Parameter arguments: argument parser result.
+    /// - Returns: the platform that should be used for the project.
+    fileprivate func platform(arguments: ArgumentParser.Result) throws -> Platform {
+        if let platformString = arguments.get(self.platformArgument) {
+            let valid = ["ios", "macos"]
+            if valid.contains(platformString) {
+                return (platformString == "ios") ? .iOS : .macOS
+            } else {
+                throw ArgumentParserError.invalidValue(argument: "platform", error: .custom("Platform should be either ios or macos"))
+            }
+        } else {
+            return .iOS
+        }
     }
 }

--- a/Sources/xpmkit/Commands/InitCommand.swift
+++ b/Sources/xpmkit/Commands/InitCommand.swift
@@ -106,9 +106,6 @@ public class InitCommand: NSObject, Command {
          let project = Project(name: "\(name)",
                       schemes: [
                           /* Project schemes are defined here */
-                          Scheme(name: "\(name)",
-                                 shared: true,
-                                 buildAction: BuildAction(targets: ["\(name)"])),
                       ],
                       settings: Settings(base: [:]),
                       targets: [

--- a/Sources/xpmkit/Linter/TargetLinter.swift
+++ b/Sources/xpmkit/Linter/TargetLinter.swift
@@ -47,7 +47,7 @@ class TargetLinter: TargetLinting {
         let sourcesPhases = target.buildPhases
             .filter({ $0 is SourcesBuildPhase })
             .count
-        if sourcesPhases == 0 { return [] }
+        if sourcesPhases <= 1 { return [] }
         return [LintingIssue(reason: "The target \(target.name) has more than one sources build phase.", severity: .error)]
     }
 
@@ -59,7 +59,7 @@ class TargetLinter: TargetLinting {
         let headerPhases = target.buildPhases
             .filter({ $0 is HeadersBuildPhase })
             .count
-        if headerPhases == 0 { return [] }
+        if headerPhases <= 1 { return [] }
         return [LintingIssue(reason: "The target \(target.name) has more than one headers build phase.", severity: .error)]
     }
 }

--- a/Sources/xpmkit/Utils/InfoPlistProvisioner.swift
+++ b/Sources/xpmkit/Utils/InfoPlistProvisioner.swift
@@ -56,10 +56,15 @@ class InfoPlistProvisioner: InfoPlistProvisioning {
             base["CFBundlePackageType"] = "APPL"
 
             // Framework
-        } else {
+        } else if product == .framework {
             base["CFBundleVersion"] = "$(CURRENT_PROJECT_VERSION)"
             base["CFBundlePackageType"] = "FMWK"
             base["NSPrincipalClass"] = ""
+
+            // Tests bundle
+        } else if product == .unitTests || product == .uiTests {
+            base["CFBundleVersion"] = "1"
+            base["CFBundlePackageType"] = "BNDL"
         }
 
         // macOS application

--- a/Tests/xpmkitTests/Commands/InitCommandTests.swift
+++ b/Tests/xpmkitTests/Commands/InitCommandTests.swift
@@ -32,27 +32,27 @@ final class InitCommandTests: XCTestCase {
         XCTAssertTrue(parser.subparsers.keys.contains(InitCommand.command))
     }
 
-    func test_pathArgument() {
-        XCTAssertEqual(subject.pathArgument.shortName, "-p")
-        XCTAssertEqual(subject.pathArgument.usage, "The path where the Project.swift file will be generated")
-        XCTAssertEqual(subject.pathArgument.completion, ShellCompletion.filename)
+    func test_productArgument() {
+        XCTAssertEqual(subject.productArgument.name, "--product")
+        XCTAssertTrue(subject.productArgument.isOptional)
+        XCTAssertEqual(subject.productArgument.usage, "The product (app or framework) the generated project will build.")
+        XCTAssertEqual(subject.productArgument.completion, ShellCompletion.values([
+            (value: "app", description: "Application"),
+            (value: "framework", description: "Framework"),
+        ]))
+    }
+
+    func test_platformArgument() {
+        XCTAssertEqual(subject.platformArgument.name, "--platform")
+        XCTAssertTrue(subject.platformArgument.isOptional)
+        XCTAssertEqual(subject.platformArgument.usage, "The platform (ios or macos) the product will be for.")
+        XCTAssertEqual(subject.platformArgument.completion, ShellCompletion.values([
+            (value: "ios", description: "iOS platform"),
+            (value: "macos", description: "macOS platform"),
+        ]))
     }
 
     func test_command() throws {
-        let tmpDir = try TemporaryDirectory(removeTreeOnDeinit: true)
-        try "".write(toFile: tmpDir.path.appending(component: "Info.plist").asString, atomically: true, encoding: .utf8)
-        try "".write(toFile: tmpDir.path.appending(component: "Debug.xcconfig").asString, atomically: true, encoding: .utf8)
-        let result = try parser.parse([InitCommand.command, "-p", tmpDir.path.asString])
-        try subject.run(with: result)
-        let project = try Project.at(tmpDir.path, context: graphLoaderContext)
-        XCTAssertEqual(project.name, tmpDir.path.components.last)
-        XCTAssertEqual(project.schemes.count, 1)
-        XCTAssertEqual(project.targets.first?.name, tmpDir.path.components.last)
-        XCTAssertEqual(project.targets.first?.platform, .iOS)
-        XCTAssertEqual(project.targets.first?.product, .app)
-        XCTAssertEqual(project.targets.first?.bundleId, "com.xcodepm.\(tmpDir.path.components.last!)")
-        XCTAssertEqual(project.targets.first?.dependencies.count, 0)
-        XCTAssertNil(project.targets.first?.settings)
-        XCTAssertEqual(project.targets.first?.buildPhases.count, 1)
+
     }
 }


### PR DESCRIPTION
### Short description 📝

The current init command generates just a `Project.swift` whose project cannot be generated because the `Info.plist` file is missing. That makes the experience of trying the tool for the first time very bad.

### Solution 📦
Improve the init command to generate, not only the `Project.swift` but the `Info.plist` files and the minimum source files to get an app or framework building and running for iOS and macOS.

The new interface of the command looks like:

```
xpm init --platform ios --product app
```

If the arguments are not passed, it assumes that is an app for iOS.
